### PR TITLE
functions which contain pthread but are not pthread functions should …

### DIFF
--- a/hybris/common/hooks.c
+++ b/hybris/common/hooks.c
@@ -1681,7 +1681,7 @@ void *get_hooked_symbol(char *sym)
         }
         ptr++;
     }
-    if (strstr(sym, "pthread") != NULL)
+    if (strncmp(sym, "__pthread", 9) == 0 || strncmp(sym, "pthread", 7) == 0)
     {
         /* safe */
         if (strcmp(sym, "pthread_sigmask") == 0)


### PR DESCRIPTION
…not be hooked to negative numbers if no hook exists